### PR TITLE
Call publisher directly from releaser workflow

### DIFF
--- a/.github/workflows/publisher.yaml
+++ b/.github/workflows/publisher.yaml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
 
 jobs:
   publish:
@@ -20,6 +25,15 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.2
 
+      - name: Get version
+        run: |
+          version=${{ inputs.version }}
+          if [ -n "$version" ]; then
+            echo "latest_release=$version" >> $GITHUB_ENV
+          else
+            echo "latest_release=$(curl --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --silent https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -r .tag_name | sed s/v// )" >> $GITHUB_ENV
+          fi
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3.1.0
         with:
@@ -27,10 +41,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish
+      - name: Build and publish
         uses: home-assistant/builder@master
         with:
           args: |
             --${{ matrix.arch }} \
+            --version ${{ env.latest_release }} \
             --target /data/ \
             --addon

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -9,11 +9,14 @@ on:
 name: Releaser
 
 jobs:
-  build:
+  release:
     name: Create Release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semver.outputs.semver }}
     permissions:
       contents: write
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,6 +53,7 @@ jobs:
           path: repo
           repository: lildude/ha-addons
           token: ${{ secrets.HA_ADDONS_PAT }}
+
       - name: Update addon repo
         run: |
           cp -vf ${{ github.workspace }}/ghostfolio/*.png ${{ github.workspace }}/repo/ghostfolio
@@ -64,3 +68,13 @@ jobs:
             git push
           fi
         working-directory: ${{ github.workspace }}/repo/ghostfolio
+
+  build:
+    name: Build addon
+    needs: release
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publisher.yaml
+    with:
+      version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
It appears the release publish event doesn't always trigger when the release is created via an actions workflow, so lets skip it and call the publisher workflow directly.