### PR TITLE
Add support for running on an exposed port

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -35,6 +35,8 @@ The configuration is self-explanatory, but essentially we need details about acc
 
 Remember to restart the add-on when the configuration is changed.
 
+To use this add-on with a reverse proxy, like [Nginx Proxy Manager][rev-proxy], you will need to enable "Show disabled ports" in the Network section of the add-on configuration and set a port.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases] functionality.
@@ -56,3 +58,4 @@ To destroy this data, you'll need to either uninstall the PostgreSQL add-on or c
 [postgres]: https://github.com/matt-FFFFFF/hassio-addon-postgres
 [releases]: https://github.com/lildude/ha-addon-ghostfolio/releases
 [semver]: https://semver.org/spec/v2.0.0.html
+[rev-proxy]: https://github.com/hassio-addons/addon-nginx-proxy-manager

--- a/rootfs/etc/services.d/ghostfolio/run
+++ b/rootfs/etc/services.d/ghostfolio/run
@@ -51,10 +51,14 @@ ingress_entry=$(curl -X GET \
                      -s http://supervisor/addons/self/info | \
                      jq -r '.data.ingress_entry')
 
-if bashio::var.is_empty "port"; then
+if bashio::var.is_empty "$(bashio::addon.port 3333)"; then
   if [[ $(grep hassio_ingress /ghostfolio/apps/client/en/main.*.js) -eq 0 ]]; then
-    sed -Ei "s^(\`|\")/api^\1${ingress_entry}/api^g" /ghostfolio/apps/client/*/*.js
-    sed -Ei "s^\(/assets^\(${ingress_entry}/assets^g" /ghostfolio/apps/client/*/*.js
+    sed -Ei.direct "s^(\`|\")/api^\1${ingress_entry}/api^g" /ghostfolio/apps/client/*/*.js
+    sed -Ei.direct "s^\(/assets^\(${ingress_entry}/assets^g" /ghostfolio/apps/client/*/*.js
+  fi
+else
+  if [[ $(find "/ghostfolio/apps/client/en/*.js.direct" 2> /dev/null | wc -l) -gt 0 ]]; then
+    find /ghostfolio/apps/ -name '*.direct' -exec sh -c 'echo "$0" "${0%.direct}"' {} \;
   fi
 fi
 

--- a/rootfs/etc/services.d/ghostfolio/run
+++ b/rootfs/etc/services.d/ghostfolio/run
@@ -51,9 +51,11 @@ ingress_entry=$(curl -X GET \
                      -s http://supervisor/addons/self/info | \
                      jq -r '.data.ingress_entry')
 
-if [[ $(grep hassio_ingress /ghostfolio/apps/client/en/main.*.js) -eq 0 ]]; then
-  sed -Ei "s^(\`|\")/api^\1${ingress_entry}/api^g" /ghostfolio/apps/client/*/*.js
-  sed -Ei "s^\(/assets^\(${ingress_entry}/assets^g" /ghostfolio/apps/client/*/*.js
+if bashio::var.is_empty "port"; then
+  if [[ $(grep hassio_ingress /ghostfolio/apps/client/en/main.*.js) -eq 0 ]]; then
+    sed -Ei "s^(\`|\")/api^\1${ingress_entry}/api^g" /ghostfolio/apps/client/*/*.js
+    sed -Ei "s^\(/assets^\(${ingress_entry}/assets^g" /ghostfolio/apps/client/*/*.js
+  fi
 fi
 
 bashio::log.info "Starting Ghostfolio"


### PR DESCRIPTION
The add-on currently expects to only be used with ingress and not directly on an exposed port. To support this, we manipulate some of the URLs in the code on startup to use the ingress path.

As a result of this, the add-on won't work when attempting to access via an exposed port directly as would be the case when using a reverse proxy as all the urls would be incorrect. This corrects that behaviour to only change the URLs if the external port is not configured in the add-on configuration.

This is not enabled by default as it's a security risk and I don't want to be responsible for people shooting themselves in the foot; if you need this, you are knowledgeable to know the risks involved with exposing the add-on on a directly accessible port. It is also [discouraged](https://www.home-assistant.io/blog/2019/04/15/hassio-ingress/):

> If an add-on is going to support both, you should not have the add-on exposed on a port enabled by default. Instead, allow users to enable the port access by assigning a port number in the “Network” section of the add-on configuration panel.

Closes https://github.com/lildude/ha-addon-ghostfolio/issues/15