### PR TITLE
Improve ingress proxy configuration

### DIFF
--- a/rootfs/etc/nginx/conf.d/ghostfolio.conf
+++ b/rootfs/etc/nginx/conf.d/ghostfolio.conf
@@ -22,15 +22,18 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Referer $http_referer;
         proxy_set_header Origin "";
-        proxy_set_header X-Real-IP $remote_addr;
 
         proxy_pass http://127.0.0.1:3333;
-        proxy_redirect '/' $http_x_ingress_path/;
         proxy_set_header Accept-Encoding "";
+        proxy_set_header X-Ingress-Path $http_x_ingress_path;
 
+        sub_filter_types *;
         sub_filter_once off;
         sub_filter 'href="/' 'href="$http_x_ingress_path/';
         sub_filter '<script src="/' '<script src="$http_x_ingress_path/';
         sub_filter "top.location.href='" "top.location.href='$http_x_ingress_path";
+        sub_filter "`/api" "`$http_x_ingress_path/api";
+        sub_filter '"/api' "\"$http_x_ingress_path/api";
+        sub_filter '/assets' "$http_x_ingress_path/assets";
     }
 }

--- a/rootfs/etc/services.d/ghostfolio/run
+++ b/rootfs/etc/services.d/ghostfolio/run
@@ -45,23 +45,6 @@ DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST:$POSTGRE
 export ACCESS_TOKEN_SALT JWT_SECRET_KEY POSTGRES_HOST POSTGRES_DB POSTGRES_PASS POSTGRES_PORT POSTGRES_USER \
        API_KEY_COINGECKO_DEMO API_KEY_COINGECKO_PRO REDIS_HOST REDIS_PORT NODE_ENV DATABASE_URL
 
-ingress_entry=$(curl -X GET \
-                     -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
-                     -H "Content-Type: application/json" \
-                     -s http://supervisor/addons/self/info | \
-                     jq -r '.data.ingress_entry')
-
-if bashio::var.is_empty "$(bashio::addon.port 3333)"; then
-  if [[ $(grep hassio_ingress /ghostfolio/apps/client/en/main.*.js) -eq 0 ]]; then
-    sed -Ei.direct "s^(\`|\")/api^\1${ingress_entry}/api^g" /ghostfolio/apps/client/*/*.js
-    sed -Ei.direct "s^\(/assets^\(${ingress_entry}/assets^g" /ghostfolio/apps/client/*/*.js
-  fi
-else
-  if [[ $(find "/ghostfolio/apps/client/en/*.js.direct" 2> /dev/null | wc -l) -gt 0 ]]; then
-    find /ghostfolio/apps/ -name '*.direct' -exec sh -c 'echo "$0" "${0%.direct}"' {} \;
-  fi
-fi
-
 bashio::log.info "Starting Ghostfolio"
 cd /ghostfolio/apps/api
 if bashio::config.true 'silent'; then


### PR DESCRIPTION
Just after finishing off https://github.com/lildude/ha-addon-ghostfolio/pull/16 I realised I shouldn't need to do all this file modification if the proxy config was working as it should so I took some time today to move the direct file manipulation into the reverse proxy config.

We now get ingress and exposed port access without changing the original files which is much cleaner.

