### PR TITLE
Stop Ghostfolio logout signing the user out of Home Assistant

### DIFF
--- a/rootfs/etc/nginx/conf.d/ghostfolio.conf
+++ b/rootfs/etc/nginx/conf.d/ghostfolio.conf
@@ -22,15 +22,18 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Referer $http_referer;
         proxy_set_header Origin "";
-        proxy_set_header X-Real-IP $remote_addr;
 
         proxy_pass http://127.0.0.1:3333;
-        proxy_redirect '/' $http_x_ingress_path/;
         proxy_set_header Accept-Encoding "";
+        proxy_set_header X-Ingress-Path $http_x_ingress_path;
 
+        sub_filter_types *;
         sub_filter_once off;
         sub_filter 'href="/' 'href="$http_x_ingress_path/';
         sub_filter '<script src="/' '<script src="$http_x_ingress_path/';
         sub_filter "top.location.href='" "top.location.href='$http_x_ingress_path";
+        sub_filter "`/api" "`$http_x_ingress_path/api";
+        sub_filter '"/api' "\"$http_x_ingress_path/api";
+        sub_filter '/assets' "$http_x_ingress_path/assets";
     }
 }

--- a/rootfs/etc/nginx/conf.d/ghostfolio.conf
+++ b/rootfs/etc/nginx/conf.d/ghostfolio.conf
@@ -31,9 +31,12 @@ server {
         sub_filter_once off;
         sub_filter 'href="/' 'href="$http_x_ingress_path/';
         sub_filter '<script src="/' '<script src="$http_x_ingress_path/';
-        sub_filter "top.location.href='" "top.location.href='$http_x_ingress_path";
         sub_filter "`/api" "`$http_x_ingress_path/api";
         sub_filter '"/api' "\"$http_x_ingress_path/api";
-        sub_filter '/assets' "$http_x_ingress_path/assets";
+        sub_filter "/assets" "$http_x_ingress_path/assets";
+        sub_filter "document.location.href=`/" "document.location.href=`$http_x_ingress_path/";
+        # Force sign out to only remove the tokens Ghostfolio sets
+        sub_filter "localStorage.clear()" "localStorage.removeItem('auth-token')";
+        sub_filter "sessionStorage.clear()" "sessionStorage.removeItem('auth-token')";
     }
 }

--- a/rootfs/etc/services.d/ghostfolio/run
+++ b/rootfs/etc/services.d/ghostfolio/run
@@ -45,23 +45,6 @@ DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST:$POSTGRE
 export ACCESS_TOKEN_SALT JWT_SECRET_KEY POSTGRES_HOST POSTGRES_DB POSTGRES_PASS POSTGRES_PORT POSTGRES_USER \
        API_KEY_COINGECKO_DEMO API_KEY_COINGECKO_PRO REDIS_HOST REDIS_PORT NODE_ENV DATABASE_URL
 
-ingress_entry=$(curl -X GET \
-                     -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
-                     -H "Content-Type: application/json" \
-                     -s http://supervisor/addons/self/info | \
-                     jq -r '.data.ingress_entry')
-
-if bashio::var.is_empty "$(bashio::addon.port 3333)"; then
-  if [[ $(grep hassio_ingress /ghostfolio/apps/client/en/main.*.js) -eq 0 ]]; then
-    sed -Ei.direct "s^(\`|\")/api^\1${ingress_entry}/api^g" /ghostfolio/apps/client/*/*.js
-    sed -Ei.direct "s^\(/assets^\(${ingress_entry}/assets^g" /ghostfolio/apps/client/*/*.js
-  fi
-else
-  if [[ $(find "/ghostfolio/apps/client/en/*.js.direct" 2> /dev/null | wc -l) -gt 0 ]]; then
-    find /ghostfolio/apps/ -name '*.direct' -exec sh -c 'echo "$0" "${0%.direct}"' {} \;
-  fi
-fi
-
 bashio::log.info "Starting Ghostfolio"
 cd /ghostfolio/apps/api
 if bashio::config.true 'silent'; then


### PR DESCRIPTION
As reported in https://github.com/lildude/ha-addon-ghostfolio/issues/15, logging out of Ghostfolio when using ingress would sign you out of Home Assistant too.

This is caused by Ghostfolio's signout clearing all the session info on signout [here](https://github.com/ghostfolio/ghostfolio/blob/d735e4db75f9ac88994b89ed2234fb168ec56a68/apps/client/src/app/services/token-storage.service.ts#L38-L39), not just the auth token it sets. 

This PR fixes this by replacing those lines as part of the reverse proxy config so we only remove the auth-token set by Ghostfolio. It also fixes the issue where logging out would take you to an invalid page.

Builds on https://github.com/lildude/ha-addon-ghostfolio/pull/18