### PR TITLE
Renovate and releaser improvements

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,12 +8,16 @@
   "prBodyTemplate": "{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}",
   "semanticCommits": "disabled",
   "commitMessageTopic": "{{#if (containsString depName 'ghostfolio')}}Ghostfolio{{else}}{{depName}}{{/if}}",
+  "enabledManagers": ["custom.regex", "ci.github-actions"],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": "^build\\.json$",
+      "fileMatch": ["^Dockerfile$", "^build.json$"],
+      "matchStringsStrategy": "any",
       "matchStrings": [
-        "\"ghostfolio_version\": \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+        "FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
+        "\"ghostfolio_version\": \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "ghostfolio/ghostfolio"

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -39,10 +39,20 @@ jobs:
           git tag -a v${{ steps.semver.outputs.semver }} -m 'Release automation'
           git push --tags
         working-directory: ${{ github.workspace }}/ghostfolio
+      - name: Get Ghostfolio release notes
+        run: |
+          gh pr list --repo lildude/ha-addon-ghostfolio --state=merged --search="Update Ghostfolio" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
+          if [ -s changelog.tmp ]; then
+            echo "## Ghostfolio Release Notes" > CHANGELOG.txt
+            cat changelog.tmp >> CHANGELOG.txt
+            echo "---" >> CHANGELOG.txt
+          fi
+          rm -f CHANGELOG.txt
       - name: Create release
         uses: softprops/action-gh-release@v2.0.5
         with:
           tag_name: v${{ steps.semver.outputs.semver }}
+          body_path: CHANGELOG.txt
           generate_release_notes: true
           draft: false
           prerelease: false


### PR DESCRIPTION
Improve the renovate configuration so all the relevant places are updated with each new GitHub release of Ghostfolio.

Also update the releaser to pull in the Ghostfolio release notes into our release notes so peeps can see the Ghostfolio changes, if any, directly in the changelog on Home Assistant.