### PR TITLE
Replace docker/login-action in publisher with manual login

### DIFF
--- a/.github/workflows/publisher.yaml
+++ b/.github/workflows/publisher.yaml
@@ -35,11 +35,7 @@ jobs:
           fi
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Build and publish
         uses: home-assistant/builder@master


### PR DESCRIPTION
The action for some unknown reason isn't finding the `secrets.GITHUB_TOKEN` so hopefully bypassing it will solve the problem.