### PR TITLE
Revert "Replace docker/login-action in publisher with manual login"

### DIFF
--- a/.github/workflows/publisher.yaml
+++ b/.github/workflows/publisher.yaml
@@ -35,7 +35,11 @@ jobs:
           fi
 
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish
         uses: home-assistant/builder@master


### PR DESCRIPTION
Reverts lildude/ha-addon-ghostfolio#54

This didn't work and the token appears to still be empty so this isn't a problem with the action. Not sure what the problem is as I've not changed anything.