### PR TITLE
Change Postgres recommendation

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -17,7 +17,7 @@ The configuration is self-explanatory, but essentially we need details about acc
 
 - `database_port`: The port your PostgreSQL server is listening on. Default: `5432`.
 
-- `database_host`: The hostname of your PostgreSQL server. Default: `29b65938-postgres` for the [PostgreSQL add-on][postgres].
+- `database_host`: The hostname of your PostgreSQL server.
 
 - `database_name`: The name of the PostgreSQL database to create and use. Default: `ghostfolio`.
 
@@ -55,7 +55,6 @@ To destroy this data, you'll need to either uninstall the PostgreSQL add-on or c
 
 [docker]: https://hub.docker.com/r/ghostfolio/ghostfolio
 [ghostfolio]: https://ghostfol.io
-[postgres]: https://github.com/alexbelgium/hassio-addons/tree/master/postgres
 [releases]: https://github.com/lildude/ha-addon-ghostfolio/releases
 [semver]: https://semver.org/spec/v2.0.0.html
 [rev-proxy]: https://github.com/hassio-addons/addon-nginx-proxy-manager

--- a/DOCS.md
+++ b/DOCS.md
@@ -55,7 +55,7 @@ To destroy this data, you'll need to either uninstall the PostgreSQL add-on or c
 
 [docker]: https://hub.docker.com/r/ghostfolio/ghostfolio
 [ghostfolio]: https://ghostfol.io
-[postgres]: https://github.com/matt-FFFFFF/hassio-addon-postgres
+[postgres]: https://github.com/alexbelgium/hassio-addons/tree/master/postgres
 [releases]: https://github.com/lildude/ha-addon-ghostfolio/releases
 [semver]: https://semver.org/spec/v2.0.0.html
 [rev-proxy]: https://github.com/hassio-addons/addon-nginx-proxy-manager

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ This addon allows you to run [Ghostfolio][ghostfolio] on your Home Assistant ser
 ## Requirements
 
 Ghostfolio needs a PostgreSQL database.
-All development and testing has been done using [PostgreSQL add-on][postgres] for convenience but you're welcome to use your own.
-
-For convenience, my [add-ons repository][addons-repo] includes configuration that points to the [PostgreSQL add-on][postgres] so you can install everything from one repo.
+I recommend using the [PostgreSQL add-on][alexbelgium-postgres] from @alexbelgium's repository if you aren't already using Postgres.
 
 ## Installation
 
@@ -44,6 +42,7 @@ The installation of this add-on is pretty straightforward and no different to in
 
 [addon]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Flildude%2Fha-addons
 [addons-repo]: https://github.com/lildude/ha-addons
+[alexbelgium-postgres]: https://github.com/alexbelgium/hassio-addons/tree/master/postgres
 [archs]: https://img.shields.io/badge/dynamic/json?color=green&label=Arch&query=%24.arch&url=https%3A%2F%2Fraw.githubusercontent.com%2Flildude%2Fha-addon-ghostfolio%2Fmain%2Fconfig.json
 [dark]: https://raw.githubusercontent.com/lildude/ha-addon-ghostfolio/main/imgs/screenshot-dark.png
 [docker]: https://hub.docker.com/r/ghostfolio/ghostfolio

--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
       "database_user": null,
       "database_pass": null,
       "database_port": 5432,
-      "database_host": "29b65938-postgres",
+      "database_host": null,
       "database_name": "ghostfolio"
   },
   "schema": {


### PR DESCRIPTION
The original Postgres add-on is no longer maintained. This PR updates the docs and config to recommend https://github.com/alexbelgium/hassio-addons/tree/master/postgres.

Closes https://github.com/alexbelgium/hassio-addons/tree/master/postgres