### PR TITLE
Add optional environment variables configuration option and force timezone to use UTC

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -33,6 +33,15 @@ The configuration is self-explanatory, but essentially we need details about acc
 
 - `silent`: (Optional) Hide all output except errors in the log file. Default: `false`.
 
+- `env_vars`: (Optional) Set additional environment variables for Ghostfolio which aren't currently exposed by the configuration options in this add-on.
+
+  Each entry is made up of a name and value:
+
+  - `name`: The case-sensitive environment variable name.
+  - `value`: The value to be set in the environment variable.
+
+  Note: These will also overwrite any environment variable set using the configuration options above.
+
 Remember to restart the add-on when the configuration is changed.
 
 To use this add-on with a reverse proxy, like [Nginx Proxy Manager][rev-proxy], you will need to enable "Show disabled ports" in the Network section of the add-on configuration and set a port.

--- a/config.json
+++ b/config.json
@@ -23,7 +23,8 @@
       "database_pass": null,
       "database_port": 5432,
       "database_host": null,
-      "database_name": "ghostfolio"
+      "database_name": "ghostfolio",
+      "env_vars": []
   },
   "schema": {
       "database_user": "str",
@@ -35,7 +36,11 @@
       "api_key_coingecko_pro": "str?",
       "access_token_salt": "str?",
       "jwt_secret_key": "str?",
-      "silent": "bool?"
+      "silent": "bool?",
+      "env_vars": [{
+          "name": "str?",
+          "value": "str?"
+      }]
   },
   "codenotary": "colin@symr.io",
   "image": "ghcr.io/lildude/ha-addon-ghostfolio-{arch}"

--- a/rootfs/etc/services.d/ghostfolio/run
+++ b/rootfs/etc/services.d/ghostfolio/run
@@ -45,6 +45,14 @@ DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST:$POSTGRE
 export ACCESS_TOKEN_SALT JWT_SECRET_KEY POSTGRES_HOST POSTGRES_DB POSTGRES_PASS POSTGRES_PORT POSTGRES_USER \
        API_KEY_COINGECKO_DEMO API_KEY_COINGECKO_PRO REDIS_HOST REDIS_PORT NODE_ENV DATABASE_URL
 
+# These are optional and applied last so we can override those set above if needed.
+for env_var in $(bashio::config 'env_vars|keys'); do
+    name=$(bashio::config "env_vars[${env_var}].name")
+    value=$(bashio::config "env_vars[${env_var}].value")
+    bashio::log.debug "Setting Env Variable ${name} to ${value}"
+    export "${name}=${value}"
+done
+
 bashio::log.info "Starting Ghostfolio"
 cd /ghostfolio/apps/api
 if bashio::config.true 'silent'; then

--- a/rootfs/etc/services.d/ghostfolio/run
+++ b/rootfs/etc/services.d/ghostfolio/run
@@ -41,9 +41,10 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 NODE_ENV=production
 DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB?connect_timeout=300&sslmode=prefer"
+TZ=UTC # Force timezone to prevent https://github.com/ghostfolio/ghostfolio/issues/2669 which is probably due to https://github.com/brianc/node-postgres/issues/2141
 
 export ACCESS_TOKEN_SALT JWT_SECRET_KEY POSTGRES_HOST POSTGRES_DB POSTGRES_PASS POSTGRES_PORT POSTGRES_USER \
-       API_KEY_COINGECKO_DEMO API_KEY_COINGECKO_PRO REDIS_HOST REDIS_PORT NODE_ENV DATABASE_URL
+       API_KEY_COINGECKO_DEMO API_KEY_COINGECKO_PRO REDIS_HOST REDIS_PORT NODE_ENV DATABASE_URL TZ
 
 # These are optional and applied last so we can override those set above if needed.
 for env_var in $(bashio::config 'env_vars|keys'); do

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -29,3 +29,6 @@ configuration:
   silent:
     name: Silent mode
     description: Hide all output except errors in the log file.
+  env_vars:
+    name: Additional Environment Variables
+    description: Set additional environment variables for Ghostfolio which aren't currently exposed by the configuration options in this add-on.

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -30,5 +30,5 @@ configuration:
     name: Silent mode
     description: Hide all output except errors in the log file.
   env_vars:
-    name: Additional Environment Variables
+    name: Environment Variables
     description: Set additional environment variables for Ghostfolio which aren't currently exposed by the configuration options in this add-on.


### PR DESCRIPTION
A lot of Ghostfolio is [configured via environment variables](https://github.com/ghostfolio/ghostfolio?tab=readme-ov-file#supported-environment-variables). This addon maps most of those to configuration options, but in future it's possible I'll miss a new variable or we need to force an override for debugging or other purposes.

This PR helps with these scenarios by adding a new configuration option.

It also forces the addon container to use the UTC timezone to workaround https://github.com/ghostfolio/ghostfolio/issues/2669 which is probably due to https://github.com/brianc/node-postgres/issues/2141

- Closes https://github.com/lildude/ha-addon-ghostfolio/issues/66