### PR TITLE
Use a fixed version for the builder

### DIFF
--- a/.github/workflows/publisher.yaml
+++ b/.github/workflows/publisher.yaml
@@ -42,7 +42,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish
-        uses: home-assistant/builder@master
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             --${{ matrix.arch }} \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Build add-on
-        uses: home-assistant/builder@master
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             --test \


### PR DESCRIPTION
The current master is [borked](https://github.com/home-assistant/builder/issues/212). 