### PR TITLE
Improve release notes gathering

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get Ghostfolio release notes
         run: |
           touch CHANGELOG.txt
-          gh pr list --repo lildude/ha-addon-ghostfolio --state=merged --search="Update Ghostfolio" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
+          gh pr list --repo lildude/ha-addon-ghostfolio --state=merged --search="Update Ghostfolio to" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
           if [ -s changelog.tmp ]; then
             echo "## Ghostfolio Release Notes" > CHANGELOG.txt
             cat changelog.tmp >> CHANGELOG.txt


### PR DESCRIPTION
The previous update accidentally made the release notes collecting worse in that the search wasn't precise enough so it didn't get the upstream release notes. This fixes that.