### PR TITLE
Revert "Update Ghostfolio to v2.140.0"

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,11 +1,11 @@
 {
   "build_from": {
-    "aarch64": "ghostfolio/ghostfolio:2.140.0",
-    "amd64": "ghostfolio/ghostfolio:2.140.0",
-    "armv7": "ghostfolio/ghostfolio:2.140.0"
+    "aarch64": "ghostfolio/ghostfolio:2.139.1",
+    "amd64": "ghostfolio/ghostfolio:2.139.1",
+    "armv7": "ghostfolio/ghostfolio:2.139.1"
   },
   "args": {
-    "ghostfolio_version": "2.140.0"
+    "ghostfolio_version": "2.139.1"
   },
   "codenotary": {
     "signer": "colin@symr.io"


### PR DESCRIPTION
Reverts lildude/ha-addon-ghostfolio#123

I missed that CI failed - looks like upstream forgot to push the docker containers.

Reverting for now.