### PR TITLE
Don't set `API_KEY_COINGECKO_PRO` and `API_KEY_COINGECKO_DEMO` environment variables to null

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/ghostfolio/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/ghostfolio/run
@@ -36,6 +36,9 @@ POSTGRES_PORT=$(bashio::config 'database_port')
 POSTGRES_USER=$(bashio::config 'database_user')
 
 API_KEY_COINGECKO_DEMO=$(bashio::config 'api_key_coingecko_demo')
+if [ "${API_KEY_COINGECKO_DEMO}" = 'null' ]; then
+  API_KEY_COINGECKO_DEMO=""
+fi
 API_KEY_COINGECKO_PRO=$(bashio::config 'api_key_coingecko_pro')
 if [ "${API_KEY_COINGECKO_PRO}" = 'null' ]; then
   API_KEY_COINGECKO_PRO=""

--- a/rootfs/etc/s6-overlay/s6-rc.d/ghostfolio/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/ghostfolio/run
@@ -37,6 +37,9 @@ POSTGRES_USER=$(bashio::config 'database_user')
 
 API_KEY_COINGECKO_DEMO=$(bashio::config 'api_key_coingecko_demo')
 API_KEY_COINGECKO_PRO=$(bashio::config 'api_key_coingecko_pro')
+if [ "${API_KEY_COINGECKO_PRO}" = 'null' ]; then
+  API_KEY_COINGECKO_PRO=""
+fi
 REDIS_HOST=localhost
 REDIS_PORT=6379
 NODE_ENV=production


### PR DESCRIPTION
This addon sets both `API_KEY_COINGECKO_DEMO` and `API_KEY_COINGECKO_PRO` when setting up the environment. Ghostfolio will always [prefer the pro key over the demo key if it's set](https://github.com/ghostfolio/ghostfolio/blob/a45ad41459a742f31252a48f836f6ffe7d1a8d59/apps/api/src/services/data-provider/coingecko/coingecko.service.ts#L39-L51).

And there's the problem… this addon is setting the value to `null` rather than an empty string because that's what [`bashio::config` does](https://github.com/hassio-addons/bashio/blob/7308cf08c8c44b51fd3c4d1857163fdd52998d99/lib/config.sh#L13-L15).

This PR fixes that by ensuring the value is empty if the config returns `null`. I've extended this to the demo key so Ghostfolio doesn't try using the demo key if it's not set in the addon.

Fixes https://github.com/lildude/ha-addon-ghostfolio/issues/164