### PR TITLE
Catch initial language redirect and improve nginx config

### DIFF
--- a/rootfs/etc/nginx/conf.d/ghostfolio.conf
+++ b/rootfs/etc/nginx/conf.d/ghostfolio.conf
@@ -23,18 +23,17 @@ server {
         proxy_set_header Referer $http_referer;
         proxy_set_header Origin "";
 
+        proxy_redirect / $http_x_ingress_path/;
         proxy_pass http://127.0.0.1:3333;
         proxy_set_header Accept-Encoding "";
         proxy_set_header X-Ingress-Path $http_x_ingress_path;
 
         sub_filter_types *;
         sub_filter_once off;
-        sub_filter 'href="/' 'href="$http_x_ingress_path/';
-        sub_filter '<script src="/' '<script src="$http_x_ingress_path/';
-        sub_filter "`/api" "`$http_x_ingress_path/api";
+        sub_filter 'base href="/' 'base href="$http_x_ingress_path/';
         sub_filter '"/api' "\"$http_x_ingress_path/api";
         sub_filter "/assets" "$http_x_ingress_path/assets";
-        sub_filter "document.location.href=`/" "document.location.href=`$http_x_ingress_path/";
+        sub_filter "../assets" "$http_x_ingress_path/assets";
         # Force sign out to only remove the tokens Ghostfolio sets
         sub_filter "localStorage.clear()" "localStorage.removeItem('auth-token')";
         sub_filter "sessionStorage.clear()" "sessionStorage.removeItem('auth-token')";


### PR DESCRIPTION
Ghostfolio 2.171.0 introduced a refactor (probably https://github.com/ghostfolio/ghostfolio/pull/4889) which introduced a redirect we weren't handling. This resulted in a 404 error when attempting to open the web UI.

This PR catches that and refactors the rest of the nginx config to be more specific.

Fixes https://github.com/lildude/ha-addon-ghostfolio/issues/161