### PR TITLE
Add back "`/api" sub_filter

### DIFF
--- a/rootfs/etc/nginx/conf.d/ghostfolio.conf
+++ b/rootfs/etc/nginx/conf.d/ghostfolio.conf
@@ -32,6 +32,7 @@ server {
         sub_filter_once off;
         sub_filter 'base href="/' 'base href="$http_x_ingress_path/';
         sub_filter '"/api' "\"$http_x_ingress_path/api";
+        sub_filter "`/api" "`$http_x_ingress_path/api";
         sub_filter "/assets" "$http_x_ingress_path/assets";
         sub_filter "../assets" "$http_x_ingress_path/assets";
         # Force sign out to only remove the tokens Ghostfolio sets


### PR DESCRIPTION
I removed this in https://github.com/lildude/ha-addon-ghostfolio/pull/167 thinking it wasn't needed anymore. Turns out it is.

Closes https://github.com/lildude/ha-addon-ghostfolio/issues/184