### PR TITLE
Don't use GitHub Actions cache for image publishing

### DIFF
--- a/.github/workflows/publisher.yaml
+++ b/.github/workflows/publisher.yaml
@@ -79,5 +79,6 @@ jobs:
             latest
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           push: "true"
+          cache-gha: "false"
           cosign: "false"
           version: ${{ needs.init.outputs.version }}


### PR DESCRIPTION
GitHub changed the permissions used for GitHub Actions cache for certain triggers as announced [here](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/). 

We use the home-assistant/builder build-image action, which defaults `cache-gha: "true"`, which makes buildx export a type=gha cache. That export step ("reserve cache") is what fails when the run gets a read-only cache token.

The clean fix is to turn off the GHA cache for this publish workflow. The action still keeps registry-based caching (`type=inline` on push + `type=registry,ref=...:latest` on restore), so build caching across releases is preserved without depending on the Actions cache token.