### PR TITLE
Resolve home assistant's http port instead of assuming 8123 and add scheduled canary runs for beta channel

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,14 @@
   "image": "ghcr.io/home-assistant/devcontainer:4-apps",
   "overrideCommand": false,
   "remoteUser": "vscode",
-  "appPort": ["7123:8123", "7357:4357"],
+  "appPort": ["7123:8123", "7180:80", "7357:4357"],
   "postStartCommand": "bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
   "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "containerEnv": {
-    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}",
+    "SUPERVISOR_CHANNEL": "stable"
   },
   "features": {
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},

--- a/.devcontainer/run-integration-test.sh
+++ b/.devcontainer/run-integration-test.sh
@@ -21,6 +21,16 @@ printf '#!/bin/sh\nexit 0\n' | sudo tee /usr/sbin/apparmor_parser > /dev/null
 sudo chmod +x /usr/sbin/apparmor_parser
 sudo sed -i 's|docker run --rm --privileged|docker run --rm --privileged -v /usr/sbin/apparmor_parser:/usr/sbin/apparmor_parser:ro|' /usr/bin/supervisor_run
 
+# supervisor_run hardcodes SUPERVISOR_DEV=1, which makes the Supervisor force its
+# update channel to dev and so install nightly Home Assistant builds whatever
+# channel is asked for.
+sudo sed -i '/-e SUPERVISOR_DEV=1/d' /usr/bin/supervisor_run
+
+# The channel is otherwise only reachable through the Supervisor API, by which
+# point it has already installed Home Assistant, so seed it before first boot.
+sudo mkdir -p /mnt/supervisor
+printf '{"channel": "%s"}\n' "${SUPERVISOR_CHANNEL}" | sudo tee /mnt/supervisor/updater.json > /dev/null
+
 echo "Home Assistant channel: ${SUPERVISOR_CHANNEL}"
 
 if [ -n "${DEBUG:-}" ]; then

--- a/.devcontainer/run-integration-test.sh
+++ b/.devcontainer/run-integration-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# run-integration-test.sh - Boot the Supervisor and run setup-ha.sh against it.
+#
+# Usage: bash .devcontainer/run-integration-test.sh [channel]
+#
+# The channel (stable, beta or dev) selects which Home Assistant release the
+# Supervisor installs. It defaults to stable so that CI tests what users actually
+# run; the devcontainer image itself defaults to dev, which means unreleased
+# Home Assistant changes would otherwise land straight in CI.
+#
+# Set DEBUG=1 to stream the Supervisor log instead of capturing it.
+
+set -euo pipefail
+
+export SUPERVISOR_CHANNEL="${1:-stable}"
+SUPERVISOR_LOG="/tmp/supervisor.log"
+
+# The devcontainer has no working AppArmor, so stub the parser out and have the
+# Supervisor mount the stub into the containers it starts.
+printf '#!/bin/sh\nexit 0\n' | sudo tee /usr/sbin/apparmor_parser > /dev/null
+sudo chmod +x /usr/sbin/apparmor_parser
+sudo sed -i 's|docker run --rm --privileged|docker run --rm --privileged -v /usr/sbin/apparmor_parser:/usr/sbin/apparmor_parser:ro|' /usr/bin/supervisor_run
+
+echo "Home Assistant channel: ${SUPERVISOR_CHANNEL}"
+
+if [ -n "${DEBUG:-}" ]; then
+  supervisor_run 2>&1 | tee "${SUPERVISOR_LOG}" &
+else
+  supervisor_run > "${SUPERVISOR_LOG}" 2>&1 &
+fi
+
+if ! bash .devcontainer/setup-ha.sh; then
+  echo "::group::Supervisor log (last 300 lines, image pull progress omitted)"
+  grep -v -E "docker_image_pull_update|pull_progress" "${SUPERVISOR_LOG}" | tail -n 300
+  echo "::endgroup::"
+  exit 1
+fi

--- a/.devcontainer/setup-ha.sh
+++ b/.devcontainer/setup-ha.sh
@@ -15,8 +15,7 @@ set -euo pipefail
 
 HA_HOST="localhost"
 # Core binds port 80 under the Supervisor from 2026.8 onwards, and 8123 before
-# that, so the port is resolved at runtime rather than assumed. Both are resolved
-# by wait_for_ha.
+# that, so wait_for_ha resolves the port at runtime rather than assuming one.
 HA_PORTS=(80 8123)
 HA_URL=""
 CLIENT_ID=""

--- a/.devcontainer/setup-ha.sh
+++ b/.devcontainer/setup-ha.sh
@@ -13,11 +13,17 @@
 
 set -euo pipefail
 
-HA_URL="http://localhost:8123"
+HA_HOST="localhost"
+# Core binds port 80 under the Supervisor from 2026.8 onwards, and 8123 before
+# that, so the port is resolved at runtime rather than assumed. Both are resolved
+# by wait_for_ha.
+HA_PORTS=(80 8123)
+HA_URL=""
+CLIENT_ID=""
+
 ALEXBELGIUM_REPO="https://github.com/alexbelgium/hassio-addons"
 ADMIN_USER="admin"
 ADMIN_PASS="pass"
-CLIENT_ID="${HA_URL}/"
 
 POSTGRES_PASSWORD="homeassistant"
 POSTGRES_USER="postgres"
@@ -101,28 +107,53 @@ ha_core_state() {
   fi
 }
 
-# HA answers on port 8123 long before the API is usable (the Supervisor serves a
-# landing page while Core starts), so readiness means "returns parseable JSON".
+# HA answers on its HTTP port long before the API is usable, and from 2026.8 the
+# port itself moved from 8123 to 80 under the Supervisor. Older releases still use
+# 8123, and during onboarding new releases answer on both - but 8123 only serves a
+# redirect that Core tears down once onboarding completes. So port 80 is tried
+# first, redirects are deliberately not followed, and a port only counts as ready
+# when it serves the onboarding payload itself rather than merely valid JSON.
+HA_PROBE=""
+
+ha_probe() {
+  local port="$1" raw status body
+  raw=$(curl -s --max-time 5 -w $'\n%{http_code}' "http://${HA_HOST}:${port}/api/onboarding" 2>/dev/null || true)
+  status=${raw##*$'\n'}
+  body=${raw%$'\n'*}
+  HA_PROBE="${HA_PROBE:+${HA_PROBE} }port=${port} http=${status:-none} body=${body:0:80}"
+  jq -e 'type == "array" and (.[0] | has("step"))' <<< "$body" > /dev/null 2>&1
+}
+
+# Sets HA_URL and CLIENT_ID on success. Must not run in a subshell.
+ha_resolve_url() {
+  local port
+  HA_PROBE=""
+  for port in "${HA_PORTS[@]}"; do
+    if ha_probe "$port"; then
+      HA_URL="http://${HA_HOST}:${port}"
+      CLIENT_ID="${HA_URL}/"
+      return 0
+    fi
+  done
+  return 1
+}
+
 wait_for_ha() {
   log "Waiting for Home Assistant to be ready..."
   local max_attempts=120
   local attempt=0
-  local raw status body=""
   while [ "$attempt" -lt "$max_attempts" ]; do
-    raw=$(curl -sL -w $'\n%{http_code}' "${HA_URL}/api/onboarding" 2>/dev/null || true)
-    status=${raw##*$'\n'}
-    body=${raw%$'\n'*}
-    if [ -n "$body" ] && jq empty <<< "$body" 2>/dev/null; then
-      ok "Home Assistant is ready"
+    if ha_resolve_url; then
+      ok "Home Assistant is ready at ${HA_URL}"
       return 0
     fi
     if [ $((attempt % 6)) -eq 0 ]; then
-      log "  attempt ${attempt}/${max_attempts}: core=$(ha_core_state) http=${status:-none} body=${body:0:120}"
+      log "  attempt ${attempt}/${max_attempts}: core=$(ha_core_state) ${HA_PROBE}"
     fi
     sleep 5
     attempt=$((attempt + 1))
   done
-  err "Home Assistant did not become ready in time (core=$(ha_core_state) http=${status:-none} body=${body:0:200})"
+  err "Home Assistant did not become ready in time (core=$(ha_core_state) ${HA_PROBE})"
 }
 
 # --- Step 1: Complete onboarding ---
@@ -416,9 +447,16 @@ main() {
 
   echo ""
   ok "Setup complete!"
+  local host_port
+  # Mirrors the appPort list in devcontainer.json.
+  case "${HA_URL##*:}" in
+    80) host_port=7180 ;;
+    *) host_port=7123 ;;
+  esac
   log "  Home Assistant: ${HA_URL} (user: ${ADMIN_USER}, pass: ${ADMIN_PASS})"
+  log "    from the host: http://localhost:${host_port}"
   log "  PostgreSQL: ${POSTGRES_SLUG} (user: ${POSTGRES_USER}, db: ${POSTGRES_DB})"
-  log "  Ghostfolio: accessible via HA ingress or port 7123"
+  log "  Ghostfolio: accessible via Home Assistant ingress"
 }
 
 main "$@"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
   "prBodyTemplate": "{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}",
   "semanticCommits": "disabled",
   "commitMessageTopic": "{{#if (containsString depName 'ghostfolio')}}Ghostfolio{{else}}{{depName}}{{/if}}",
-  "enabledManagers": ["custom.regex", "github-actions"],
+  "enabledManagers": ["custom.regex", "github-actions", "devcontainer"],
   "customManagers": [
     {
       "customType": "regex",

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,6 +17,13 @@ on:
       - Dockerfile
       - rootfs/**
       - .devcontainer/**
+  # Home Assistant and the third-party add-on repository this test installs both
+  # move independently of this repo, so the test can break with no change here.
+  # Run it on a schedule to catch that on main rather than on an unrelated pull
+  # request that happens to touch one of the paths above.
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
 
 jobs:
   integration:
@@ -30,17 +37,22 @@ jobs:
       - name: Run integration test in devcontainer
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         with:
-          runCmd: |
-            printf '#!/bin/sh\nexit 0\n' | sudo tee /usr/sbin/apparmor_parser > /dev/null && sudo chmod +x /usr/sbin/apparmor_parser
-            sudo sed -i 's|docker run --rm --privileged|docker run --rm --privileged -v /usr/sbin/apparmor_parser:/usr/sbin/apparmor_parser:ro|' /usr/bin/supervisor_run
-            if [ -n "${DEBUG:-}" ]; then
-              supervisor_run 2>&1 | tee /tmp/supervisor.log &
-            else
-              supervisor_run > /tmp/supervisor.log 2>&1 &
-            fi
-            if ! bash .devcontainer/setup-ha.sh; then
-              echo "::group::Supervisor log (last 300 lines, image pull progress omitted)"
-              grep -v -E "docker_image_pull_update|pull_progress" /tmp/supervisor.log | tail -n 300
-              echo "::endgroup::"
-              exit 1
-            fi
+          runCmd: bash .devcontainer/run-integration-test.sh stable
+
+  # Early warning for Home Assistant changes that have not reached stable yet.
+  # Deliberately never runs on a pull request, so a broken beta cannot block a
+  # merge, and is non-blocking when it does run.
+  canary:
+    name: Integration test (beta)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run integration test in devcontainer
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
+        with:
+          runCmd: bash .devcontainer/run-integration-test.sh beta


### PR DESCRIPTION
Home Assistant Core moved its default HTTP port from 8123 to 80 under the Supervisor in [home-assistant/core#174278](https://github.com/home-assistant/core/pull/174278), released in 2026.8.0. Port 8123 now serves only a 307 redirect, and only until onboarding completes, at which point Core tears it down. `setup-ha.sh` hardcoded 8123, so its onboarding calls received the redirect's plain text body, `307: Temporary Redirect`, instead of JSON — that is the `jq: parse error` currently blocking [#327](https://github.com/lildude/ha-addon-ghostfolio/pull/327).

## What

- Resolve the port at runtime: probe 80 then 8123, deliberately do not follow redirects, and only accept a port that serves the onboarding payload itself rather than merely valid JSON.
- Actually pin the Home Assistant channel. `SUPERVISOR_CHANNEL` on its own only selects the Supervisor image, and `supervisor_run` hardcodes `SUPERVISOR_DEV=1`, which makes the Supervisor override its own channel to dev and install nightly Core builds. Strip that and seed `updater.json` before first boot.
- Run on a schedule, so drift in Home Assistant or the third-party add-on repo surfaces on `main` instead of on whichever pull request happens to touch the trigger paths.
- Add a non-blocking `beta` canary for early warning. It never runs on a pull request, so a broken beta cannot block a merge.
- Move the inline `runCmd` into `.devcontainer/run-integration-test.sh` so both jobs share it.

## Why not just follow the redirect

Following it works on a first run, but leaves the script broken on a re-run against an already onboarded instance, since 8123 is gone by then. It also only holds for as long as a transition that Core's own comments describe as temporary is still in place.

## Validation

Ran end to end on a scratch branch against real Home Assistant: both the stable and beta jobs green, each with the Supervisor reporting the channel it was asked for and Core 2026.8.0 resolving to `http://localhost:80`. Before the dev-mode fix, both reported channel `dev` and Core `2026.9.0.dev202608050310`, which is how the no-op pin was caught.

2026.8.0 reached stable while this was in progress, so the port change is live for everyone now. Pinning the channel alone would not have avoided this.

Port resolution was also exercised against a simulated Home Assistant covering the 8123 fallback, the post-onboarding case where only 80 answers, and the negative cases: a bare redirect, a 401 while Core is still booting, and nothing listening.

## Rollback

Revert. The channel pin can be relaxed on its own by restoring `SUPERVISOR_DEV=1`, which returns CI to nightlies.